### PR TITLE
Add zcash_script_transparent_output_address() to get address from output

### DIFF
--- a/src/script/zcash_script.cpp
+++ b/src/script/zcash_script.cpp
@@ -218,36 +218,68 @@ unsigned int zcash_script_legacy_sigop_count(
     }
 }
 
-void zcash_script_transparent_output_address(
+zcash_script_uint160 zcash_script_transparent_output_address_precomputed(
+    const void* pre_preTx,
+    unsigned int nOut,
+    zcash_script_error* err)
+{
+    const PrecomputedTransaction* preTx = static_cast<const PrecomputedTransaction*>(pre_preTx);
+
+    zcash_script_uint160 r;
+    memset(&r, 0, sizeof(r));
+
+    if (nOut >= preTx->tx.vout.size()) {
+        set_error(err, zcash_script_ERR_TX_INDEX);
+        return r;
+    }
+
+    const CTxOut& out = preTx->tx.vout[nOut];
+    CScript::ScriptType scriptType = out.scriptPubKey.GetType();
+    if (scriptType == CScript::UNKNOWN) {
+        set_error(err, zcash_script_ERR_TX_INVALID_SCRIPT);
+        return r;
+    }
+    const uint160 addr = out.scriptPubKey.AddressHash();
+
+    assert(sizeof(r.value) == addr.size());
+    memcpy(r.value, addr.begin(), addr.size());
+    set_error(err, zcash_script_ERR_OK);
+    return r;
+}
+
+zcash_script_uint160 zcash_script_transparent_output_address(
     const unsigned char *txTo,
     unsigned int txToLen,
     unsigned int nOut,
-    unsigned char *address,
     zcash_script_error* err)
 {
     TxInputStream stream(SER_NETWORK, PROTOCOL_VERSION, txTo, txToLen);
     CTransaction tx;
+    zcash_script_uint160 r;
+    memset(&r, 0, sizeof(r));
+
     stream >> tx;
     if (nOut >= tx.vout.size()) {
         set_error(err, zcash_script_ERR_TX_INDEX);
-        return;
+        return r;
     }
     if (GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION) != txToLen) {
         set_error(err, zcash_script_ERR_TX_SIZE_MISMATCH);
-        return;
+        return r;
     }
 
     const CTxOut& out = tx.vout[nOut];
     CScript::ScriptType scriptType = out.scriptPubKey.GetType();
     if (scriptType == CScript::UNKNOWN) {
         set_error(err, zcash_script_ERR_TX_INVALID_SCRIPT);
-        return;
+        return r;
     }
     const uint160 addr = out.scriptPubKey.AddressHash();
 
-    memcpy(address, addr.begin(), addr.size());
+    assert(sizeof(r.value) == addr.size());
+    memcpy(r.value, addr.begin(), addr.size());
     set_error(err, zcash_script_ERR_OK);
-    return;
+    return r;
 }
 
 unsigned int zcash_script_version()

--- a/src/script/zcash_script.cpp
+++ b/src/script/zcash_script.cpp
@@ -221,6 +221,7 @@ unsigned int zcash_script_legacy_sigop_count(
 zcash_script_uint160 zcash_script_transparent_output_address_precomputed(
     const void* pre_preTx,
     unsigned int nOut,
+    zcash_script_type* type,
     zcash_script_error* err)
 {
     const PrecomputedTransaction* preTx = static_cast<const PrecomputedTransaction*>(pre_preTx);
@@ -235,9 +236,20 @@ zcash_script_uint160 zcash_script_transparent_output_address_precomputed(
 
     const CTxOut& out = preTx->tx.vout[nOut];
     CScript::ScriptType scriptType = out.scriptPubKey.GetType();
-    if (scriptType == CScript::UNKNOWN) {
-        set_error(err, zcash_script_ERR_TX_INVALID_SCRIPT);
-        return r;
+    switch (scriptType) {
+        case CScript::ScriptType::P2PKH:
+            if (type) {
+                *type = zcash_script_TYPE_P2PKH;
+            }
+            break;
+        case CScript::ScriptType::P2SH:
+            if (type) {
+                *type = zcash_script_TYPE_P2SH;
+            }
+            break;
+        default:
+            set_error(err, zcash_script_ERR_TX_INVALID_SCRIPT);
+            return r;
     }
     const uint160 addr = out.scriptPubKey.AddressHash();
 
@@ -251,6 +263,7 @@ zcash_script_uint160 zcash_script_transparent_output_address(
     const unsigned char *txTo,
     unsigned int txToLen,
     unsigned int nOut,
+    zcash_script_type* type,
     zcash_script_error* err)
 {
     TxInputStream stream(SER_NETWORK, PROTOCOL_VERSION, txTo, txToLen);
@@ -270,9 +283,20 @@ zcash_script_uint160 zcash_script_transparent_output_address(
 
     const CTxOut& out = tx.vout[nOut];
     CScript::ScriptType scriptType = out.scriptPubKey.GetType();
-    if (scriptType == CScript::UNKNOWN) {
-        set_error(err, zcash_script_ERR_TX_INVALID_SCRIPT);
-        return r;
+    switch (scriptType) {
+        case CScript::ScriptType::P2PKH:
+            if (type) {
+                *type = zcash_script_TYPE_P2PKH;
+            }
+            break;
+        case CScript::ScriptType::P2SH:
+            if (type) {
+                *type = zcash_script_TYPE_P2SH;
+            }
+            break;
+        default:
+            set_error(err, zcash_script_ERR_TX_INVALID_SCRIPT);
+            return r;
     }
     const uint160 addr = out.scriptPubKey.AddressHash();
 

--- a/src/script/zcash_script.h
+++ b/src/script/zcash_script.h
@@ -41,6 +41,7 @@ typedef enum zcash_script_error_t
     zcash_script_ERR_TX_INDEX,
     zcash_script_ERR_TX_SIZE_MISMATCH,
     zcash_script_ERR_TX_DESERIALIZE,
+    zcash_script_ERR_TX_INVALID_SCRIPT,
 } zcash_script_error;
 
 /** Script verification flags */
@@ -121,6 +122,16 @@ EXPORT_SYMBOL unsigned int zcash_script_legacy_sigop_count_precomputed(
 EXPORT_SYMBOL unsigned int zcash_script_legacy_sigop_count(
     const unsigned char *txTo,
     unsigned int txToLen,
+    zcash_script_error* err);
+
+/// Write the destination address for output nOut of the transaction
+/// txTo in the address buffer, whose length must be 20 bytes.
+/// If not NULL, err will contain an error/success code for the operation.
+EXPORT_SYMBOL void zcash_script_transparent_output_address(
+    const unsigned char *txTo,
+    unsigned int txToLen,
+    unsigned int nOut,
+    unsigned char *address,
     zcash_script_error* err);
 
 /// Returns the current version of the zcash_script library.

--- a/src/script/zcash_script.h
+++ b/src/script/zcash_script.h
@@ -33,7 +33,7 @@
 extern "C" {
 #endif
 
-#define ZCASH_SCRIPT_API_VER 2
+#define ZCASH_SCRIPT_API_VER 4
 
 typedef enum zcash_script_error_t
 {
@@ -51,6 +51,12 @@ enum
     zcash_script_SCRIPT_FLAGS_VERIFY_P2SH                = (1U << 0), // evaluate P2SH (BIP16) subscripts
     zcash_script_SCRIPT_FLAGS_VERIFY_CHECKLOCKTIMEVERIFY = (1U << 9), // enable CHECKLOCKTIMEVERIFY (BIP65)
 };
+
+/// A Zcash transparent address encoded as 20 bytes.
+typedef struct zcash_script_uint160_t
+{
+    unsigned char value[20];
+} zcash_script_uint160;
 
 /// Deserializes the given transaction and precomputes values to improve
 /// script verification performance.
@@ -124,14 +130,20 @@ EXPORT_SYMBOL unsigned int zcash_script_legacy_sigop_count(
     unsigned int txToLen,
     zcash_script_error* err);
 
-/// Write the destination address for output nOut of the transaction
-/// txTo in the address buffer, whose length must be 20 bytes.
+/// Return the destination address for transparent output nOut of the precomputed transaction
+/// pointed to by preTx.
 /// If not NULL, err will contain an error/success code for the operation.
-EXPORT_SYMBOL void zcash_script_transparent_output_address(
+EXPORT_SYMBOL zcash_script_uint160 zcash_script_transparent_output_address_precomputed(
+    const void* pre_preTx,
+    unsigned int nOut,
+    zcash_script_error* err);
+
+/// Return the destination address for transparent output nOut of the transaction txTo.
+/// If not NULL, err will contain an error/success code for the operation.
+EXPORT_SYMBOL zcash_script_uint160 zcash_script_transparent_output_address(
     const unsigned char *txTo,
     unsigned int txToLen,
     unsigned int nOut,
-    unsigned char *address,
     zcash_script_error* err);
 
 /// Returns the current version of the zcash_script library.

--- a/src/script/zcash_script.h
+++ b/src/script/zcash_script.h
@@ -52,6 +52,13 @@ enum
     zcash_script_SCRIPT_FLAGS_VERIFY_CHECKLOCKTIMEVERIFY = (1U << 9), // enable CHECKLOCKTIMEVERIFY (BIP65)
 };
 
+/** Address type enumeration */
+typedef enum zcash_script_type_t
+{
+    zcash_script_TYPE_P2PKH = 1,
+    zcash_script_TYPE_P2SH  = 2,
+} zcash_script_type;
+
 /// A Zcash transparent address encoded as 20 bytes.
 typedef struct zcash_script_uint160_t
 {
@@ -132,18 +139,22 @@ EXPORT_SYMBOL unsigned int zcash_script_legacy_sigop_count(
 
 /// Return the destination address for transparent output nOut of the precomputed transaction
 /// pointed to by preTx.
+/// If not NULL, type will contain the address type.
 /// If not NULL, err will contain an error/success code for the operation.
 EXPORT_SYMBOL zcash_script_uint160 zcash_script_transparent_output_address_precomputed(
     const void* pre_preTx,
     unsigned int nOut,
+    zcash_script_type* type,
     zcash_script_error* err);
 
 /// Return the destination address for transparent output nOut of the transaction txTo.
+/// If not NULL, type will contain the address type.
 /// If not NULL, err will contain an error/success code for the operation.
 EXPORT_SYMBOL zcash_script_uint160 zcash_script_transparent_output_address(
     const unsigned char *txTo,
     unsigned int txToLen,
     unsigned int nOut,
+    zcash_script_type* type,
     zcash_script_error* err);
 
 /// Returns the current version of the zcash_script library.


### PR DESCRIPTION
This adds a function to return an address from the specified output inside a transaction.

This is a draft because it won't get actually merged for now; after it's accepted we will point to this branch in the rust wrapper. Eventually we'll create a PR upstream, but that's not urgent.

This will be tested in the rust wrapper (https://github.com/ZcashFoundation/zcash_script) where it's easier to test.

Will eventually close https://github.com/ZcashFoundation/zebra/issues/3148

--- 


Please ensure this checklist is followed for any pull requests for this repo. This checklist must be checked by both the PR creator and by anyone who reviews the PR.
* [ ] Relevant documentation for this PR has to be completed and reviewed by @mdr0id before the PR can be merged
* [ ] A test plan for the PR must be documented in the PR notes and included in the test plan for the next regular release

As a note, all buildbot tests need to be passing and all appropriate code reviews need to be done before this PR can be merged
